### PR TITLE
Fix issue 37

### DIFF
--- a/app/Http/Controllers/CategoriaController.php
+++ b/app/Http/Controllers/CategoriaController.php
@@ -137,27 +137,36 @@ class CategoriaController extends Controller
             }
         }
         $materiais = $materiais->get();
-        // Lógica temporária para gerar códigos de barras com 6 em cada linha
+        // Lógica temporária para gerar códigos de barras com 6 ou 3 códigos em cada linha
         $n = count($materiais);
         $trs = '';
-        for($i=0; $i < floor($n/6)*6; $i = $i+6){
+        $cols = 6; // 3 ou 6
+        for($i=0; $i < floor($n/$cols)*$cols; $i = $i+$cols){
             $tr = '<tr>';
-            for($j=0; $j < 6; $j++){
+            for($j=0; $j < $cols; $j++){
                 $code = $materiais[$i+$j]->codigo;
+                $descricao = $materiais[$i+$j]->descricao;
                 $barcode = base64_encode($generator->getBarcode($code,$generator::TYPE_CODE_128));
-                $tr .= "<td><img src='data:image/png;base64,{$barcode}' width='80'> <br> {$code}</td>";
+                if($cols == 3)
+                    $tr .= "<td> <div style='width: 230px; margin: 0 auto'> {$descricao}</div>{$code} <br> <img src='data:image/png;base64,{$barcode}' width='120' style='margin-bottom: 10px'></td>";
+                else
+                    $tr .= "<td><img src='data:image/png;base64,{$barcode}' width='80'> <br> {$code}</td>";
             }
             $tr .= '</tr>';
             $trs .= $tr;
         }
         // Faltantes
         $tr = '<tr>';
-        for($i = floor($n/6)*6; $i < $n; $i++){
+        for($i = floor($n/$cols)*$cols; $i < $n; $i++){
             $code = $materiais[$i]->codigo;
+            $descricao = $materiais[$i]->descricao;
             $barcode = base64_encode($generator->getBarcode($code,$generator::TYPE_CODE_128));
-            $tr .= "<td><img src='data:image/png;base64,{$barcode}' width='80'> <br> {$code}</td>";
+            if($cols == 3)
+                $tr .= "<td> <div style='width: 230px; margin: 0 auto'> {$descricao}</div>{$code} <br> <img src='data:image/png;base64,{$barcode}' width='120' style='margin-bottom: 10px'></td>";
+            else
+                $tr .= "<td><img src='data:image/png;base64,{$barcode}' width='80'> <br> {$code}</td>";
         }
-        $faltantes = str_repeat("<td>Null</td>", 6 - $n%6);
+        $faltantes = str_repeat("<td>Null</td>", 3 - $n%3);
         $tr .= $faltantes;
         $tr .= '</tr>';
         $trs .= $tr;

--- a/app/Http/Controllers/CategoriaController.php
+++ b/app/Http/Controllers/CategoriaController.php
@@ -140,7 +140,7 @@ class CategoriaController extends Controller
         // Lógica temporária para gerar códigos de barras com 6 ou 3 códigos em cada linha
         $n = count($materiais);
         $trs = '';
-        $cols = 6; // 3 ou 6
+        $cols = (int) $request->formatacao; // 3 ou 6
         for($i=0; $i < floor($n/$cols)*$cols; $i = $i+$cols){
             $tr = '<tr>';
             for($j=0; $j < $cols; $j++){

--- a/resources/views/categorias/barcode.blade.php
+++ b/resources/views/categorias/barcode.blade.php
@@ -9,6 +9,7 @@
                 @csrf
                 <div class="row form-group">
                     <div class="col-sm">
+                        <label>Categoria:</label>
                         <select multiple class="form-control" name="categoria_id[]">
                             <option value="" selected="">- Selecione -</option>
                             @foreach ($categorias as $option)
@@ -18,6 +19,13 @@
                             @endforeach
                         </select>
                     </div>                
+                </div>
+                <div class="form-group">
+                    <label>Formatação do Código de Barras:</label>
+                    <select class="form-control" name="formatacao">
+                        <option value="6" selected>Menor: 6 colunas, apenas com o cógido do material</option>
+                        <option value="3">Maior: 3 colunas, com a descrição e o cógigo do material</option>
+                    </select>
                 </div>
                 <div class="row">
                     <div class="col-sm">


### PR DESCRIPTION
Fix #37.

O formulário para gerar o PDF com os códigos de barras dos materiais agora possui um campo *select* que permite escolher entre duas opções para a formatação do código de barras:
- **6 colunas, apenas com o código:** O PDF é gerado como está atualmente, com 6 códigos de barras por linha e apenas com o código do material abaixo das barras. 
- **3 colunas, com código e descrição:** O PDF é gerado com códigos de barras maiores, com 3 por linha e com a descrição e o código do material acima das barras.

Esta *issue* foi pensada para institutos que possam se beneficiar com outros formatos para o código de barras.