### PR TITLE
Formulário de empréstimo de material automatizado

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,3 +127,6 @@ WS_FOTO_FAKE_PATH=
 # Variáveis da aplicação
 # Permite emprestar multiplos materiais para a mesma pessoa. default=false
 #MULTIPLOS_MATERIAIS=true
+
+# Habilita a tecla Enter para submeter o fomulário de empréstimo de material. default=0
+#HABILITAR_ENTER=1

--- a/config/empresta.php
+++ b/config/empresta.php
@@ -2,5 +2,6 @@
 
 return [
     # Permite emprestar multiplos materiais para a mesma pessoa. default=false
-    'multiplosMateriais' => env('MULTIPLOS_MATERIAIS', false)
+    'multiplosMateriais' => env('MULTIPLOS_MATERIAIS', false),
+    'habilitarEnter' => env('HABILITAR_ENTER',0)
 ];

--- a/resources/views/emprestimos/usp.blade.php
+++ b/resources/views/emprestimos/usp.blade.php
@@ -10,11 +10,11 @@
                 @csrf
                 <div class="form-group">
                     <label for="material_id"><b>Código</b></label>
-                    <input type="text" class="form-control" name="material_id" value="{{ old('material_id') }}">   
+                    <input type="text" class="form-control" name="material_id" value="{{ old('material_id') }}" required autofocus>   
                 </div>
                 <div class="form-group">
                     <label for="username"><b>Número USP</b></label> 
-                    <input type="text" class="form-control" name="username" value="{{ old('username') }}">        
+                    <input type="text" class="form-control" name="username" value="{{ old('username') }}" required>        
                     <input type="text" class="form-control" name="visitante_id" hidden value="">   
                 </div>
                 <div class="form-group">
@@ -29,11 +29,15 @@
 @section('javascripts_bottom')
     <script>
 
+        /******************************************************* 
+        * Código substituído pelo atributo 'autofocus' do html5
+        * ******************************************************
         // https://stackoverflow.com/questions/277544/how-to-set-the-focus-to-the-first-input-element-in-an-html-form-independent-from
         // Foco no primeiro input da página
         $(document).ready(function() {
             $('form:first *:input[type!=hidden]:first').focus();
         });
+        ********************************************************/
 
         // jQuery plugin to prevent double submission of forms
         // https://stackoverflow.com/questions/2830542/prevent-double-submission-of-forms-in-jquery
@@ -64,7 +68,9 @@
             }
             });
         };
-        $('form').disableEnter();
+
+        if({{!config('empresta.habilitarEnter')}})
+            $('form').disableEnter();
   
     </script>
 @endsection


### PR DESCRIPTION
Fix #38 

Para dar foco no primeiro *input* do formulário de empréstimo de material, foi adicionado o atributo *autofocus* à *tag*. Dessa forma, o código JavaScript que deveria realizar esta ação foi comentado, visto que não estava funcionando corretamente. Também foi adicionado o atributo *required* aos *inputs* do formulário.

Para deixar o processo de empréstimo mais dinâmico, a opção de enviar o formulário com a tecla *Enter* foi parametrizada. Como a maioria dos modelos de leitores de barra, após a leitura do código de barras, envia o caractere correspondente à tecla *Enter* por padrão, com a tecla *Enter* habilitada é possível, na hora do empréstimo, apenas realizar a leitura dos códigos de barras que o campos vão se preenchendo e pulando para o próximo (devido ao atributo *required* presente nos *inputs*), e ao final o formulário é enviado após a leitura do último código de barras. 

Para parametrizar este comportamento foi adicionada uma variável de ambiente `HABILITAR_ENTER`, que recebe valores 0 ou 1 (correspondendo à *false* e *true* respectivamente), que determina se a tecla *Enter* deve ou não ter o comportamento de envio do formulário para dinamizar o processo de empréstimo com o leitor de código de barras.

Esta *issue* foi pensada pois como o sistema [uspdev/empresa_symfony](https://github.com/uspdev/empresta_symfony) possui tal comportamento, é interessante possibilitar que os institutos que o utilizavam assim possam utilizar este presente sistema de forma semelhante.

