### PR TITLE
Só trazer o nome no relatório se encontrar no replicado

### DIFF
--- a/resources/views/emprestimos/relatorio.blade.php
+++ b/resources/views/emprestimos/relatorio.blade.php
@@ -43,7 +43,7 @@
                 <td>{{ $emprestimo->data_devolucao ? Carbon\Carbon::parse($emprestimo->data_devolucao)->format('d/m/Y H:i:s') : '' }}</td>
                 @if($emprestimo->visitante_id == null)
                     <td>{{ $emprestimo->username }}</td>    
-                    <td>{{$pessoa::dump($emprestimo->username)['nompes']}}</td>    
+                    <td>{{ ($pessoa::dump($emprestimo->username)) ? $pessoa::dump($emprestimo->username)['nompes'] : ''}}</td>    
                     <td>{{ $pessoa::emailusp($emprestimo->username) }}</td>    
                     <td> @foreach($pessoa::telefones($emprestimo->username) as $telefone) {{ $telefone }} @endforeach</td>    
                 @else


### PR DESCRIPTION
Fix #34 

Por algum motivo no momento que foi feito o empréstimo no passado a pessoa aparecia na tabela PESSOA do replicado, porém no momento em que se gera o relatório e a pessoa foi desligada ou não pertence mais a unidade, o erro era retornado.
Como solução que pode ser melhorada, coloquei uma condição para só trazer o nome quando a pessoa for encontrada no replicado.
