### PR TITLE
Criando permissão 'balcao' para o gerenciamento dos itens emprestados

### DIFF
--- a/app/Http/Controllers/EmprestimoController.php
+++ b/app/Http/Controllers/EmprestimoController.php
@@ -10,12 +10,13 @@ use App\Models\Material;
 use Uspdev\Wsfoto;
 use Uspdev\Replicado\Pessoa;
 use App\Utils\ReplicadoUtils;
+use Illuminate\Support\Facades\Auth;
 
 class EmprestimoController extends Controller
 {
     public function __construct()
     {
-        $this->middleware('can:balcao');
+        $this->middleware('auth');
     }
     /**
      * Display a listing of the resource.
@@ -24,6 +25,8 @@ class EmprestimoController extends Controller
      */
     public function index(Request $request)
     {
+        if(!Auth::user()->hasPermissionTo('balcao')) return view('home');
+
         $query = Emprestimo::orderBy('data_emprestimo','asc')->where('data_devolucao', null);
 
         if($request->busca != null){
@@ -54,16 +57,19 @@ class EmprestimoController extends Controller
     }*/
 
     public function usp(){
+        $this->authorize('balcao');
         return view('emprestimos.usp');  
     }
 
     public function visitante(){
+        $this->authorize('balcao');
         return view('emprestimos.visitante')->with([
             'emprestimo' => New Emprestimo,
         ]);
     }
 
     public function devolucao(){
+        $this->authorize('balcao');
         return view('emprestimos.devolucao');
     }
 
@@ -75,6 +81,8 @@ class EmprestimoController extends Controller
      */
     public function store(EmprestimoRequest $request)
     {
+        $this->authorize('balcao');
+
         $validated = $request->validated();
 
         if($validated['username'] != null and ReplicadoUtils::pessoaUSP($validated['username'])[0] == null){
@@ -142,6 +150,8 @@ class EmprestimoController extends Controller
      */
     public function show(Emprestimo $emprestimo)
     {
+        $this->authorize('balcao');
+
         if($emprestimo->username) {
             $emprestimo->foto = Wsfoto::obter($emprestimo->username);
         }
@@ -174,6 +184,8 @@ class EmprestimoController extends Controller
     }*/
 
     public function devolver(Request $request){
+        $this->authorize('balcao');
+
         $request->validate([
             'material_id' => 'required',
         ]);
@@ -205,12 +217,16 @@ class EmprestimoController extends Controller
      */
     public function destroy(Emprestimo $emprestimo)
     {
+        $this->authorize('balcao');
+
         $emprestimo->delete();
         return redirect('/');
     }
 
     public function relatorio(Request $request)
     {
+        $this->authorize('balcao');
+
         $query = Emprestimo::orderBy('data_emprestimo','asc');
 
         if($request->busca != null){

--- a/app/Http/Controllers/EmprestimoController.php
+++ b/app/Http/Controllers/EmprestimoController.php
@@ -10,7 +10,7 @@ use App\Models\Material;
 use Uspdev\Wsfoto;
 use Uspdev\Replicado\Pessoa;
 use App\Utils\ReplicadoUtils;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 class EmprestimoController extends Controller
 {
@@ -25,7 +25,7 @@ class EmprestimoController extends Controller
      */
     public function index(Request $request)
     {
-        if(!Auth::user()->hasPermissionTo('balcao')) return view('home');
+        if(!Gate::allows('balcao')) return view('home');
 
         $query = Emprestimo::orderBy('data_emprestimo','asc')->where('data_devolucao', null);
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Pagination\Paginator;
+use Spatie\Permission\Models\Permission;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -29,5 +30,7 @@ class AppServiceProvider extends ServiceProvider
         if (\App::environment('production')) {
             \URL::forceScheme('https');
         }
+
+        Permission::firstOrCreate(['name' => 'balcao']);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -27,7 +28,7 @@ class AuthServiceProvider extends ServiceProvider
         $this->registerPolicies();
 
         Gate::define('balcao', function ($user) {
-            if(Gate::allows('admin')) return true;
+            if(Gate::allows('admin') || Auth::user()->hasPermissionTo('balcao')) return true;
             $verifica = User::where('username', $user->username)->where('tipo', 'Balcao')->first();
             if($verifica){
                 return true;

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,5 +1,6 @@
 @extends('laravel-usp-theme::master')
 
 @section('content')
-    Sistema de Empréstimo
+    <h5>Login efetuado com sucesso!</h5>
+    <p>Caso necessite da permissão de balcão para gerenciar os empréstimos realizados entre em contato com o administrador do sistema da unidade.</p>
 @endsection


### PR DESCRIPTION
Fix #52 

Foi criada a permissão de aplicação `balcao` para ser atribuída aos usuários que poderão gerenciar os itens emprestados e os visitantes, sendo que aqueles com permissão de administrador também poderão realizar as tarefas atribuídas à permissão de balcão.

Para os usuários logados com senha única que não forem administrados e nem possuírem a permissão de balcão é  mostrado uma mensagem confirmando o login no sistema e instruindo para procurar o administrador do sistema da unidade, caso deseje obter a permissão de balcão.