### PR TITLE
Arrumando erro no composer install ao instalar o sistema em um novo ambiente

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Este CRUD pode ser acessado clicando na engrenagem de configurações.
 - Adicionar a biblioteca PHP referente ao sgbd da base replicada
 
 ```bash
-cp .env.example .env
 composer install
+cp .env.example .env
 ```
 - Editar o arquivo .env
     - Dados da conexão na base do sistema

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -31,6 +31,5 @@ class AppServiceProvider extends ServiceProvider
             \URL::forceScheme('https');
         }
 
-        Permission::firstOrCreate(['name' => 'balcao']);
     }
 }

--- a/database/migrations/2024_04_16_141825_seed_permissions_table.php
+++ b/database/migrations/2024_04_16_141825_seed_permissions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Permission;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Permission::firstOrCreate(['name' => 'balcao']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};


### PR DESCRIPTION
A permissão `balcao` sendo criada na função `boot()` do `app/Providers/AppServiceProvider.php` estava gerando um erro ao rodar o comando `composer install` em uma instalação limpa do sistema. 

Para contornar este erro, de ser feito uma requisição da tabela antes desta ser criada, a permissão `balcao` agora está sendo criada por meio de uma migration.