### PR TITLE
Atribuindo permissões de gerenciamento ao manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Para que seja possível restringir alunos de graduação por departamento foi ad
 Exemplo: Somente Alunos de Graduação do Departamento de Ensino Relações Públicas - CRP podem retirar materiais na Categoria Equipamentos do CRP.
 Este CRUD pode ser acessado clicando na engrenagem de configurações.
 
+## Permissões
+- **balcao:** a permissão de balcão pode listar os materiais disponíveis, gerenciar os usuários visitantes e realizar os empréstimos e devoluções dos materiais.
+
+- **manager:** a permissão de manager pode realizar todas as ações da permissão balcao, bem como gerenciar os materiais, as categorias e a relação de cursos x departamentos de ensino.
+  
+- **admin:** a permissão de admin tem todas as permissões do sistema, inclusive o gerenciamento de usuários e acesso às interfaces do [uspdev/senhaunica-socialite](https://github.com/uspdev/senhaunica-socialite) e [uspdev/laravel-tools](https://github.com/uspdev/laravel-tools) 
+
 ## Procedimentos de deploy
  
 - Adicionar a biblioteca PHP referente ao sgbd da base replicada

--- a/app/Http/Controllers/CategoriaController.php
+++ b/app/Http/Controllers/CategoriaController.php
@@ -14,6 +14,11 @@ use Uspdev\Replicado\Estrutura;
 
 class CategoriaController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('can:manager');
+    }
+
     /**
      * Display a listing of the resource.
      *
@@ -21,7 +26,6 @@ class CategoriaController extends Controller
      */
     public function index(Request $request)
     {
-        $this->authorize('admin');
         $query = Categoria::orderBy('nome','asc');
 
         if($request->busca != null){
@@ -41,8 +45,6 @@ class CategoriaController extends Controller
      */
     public function create()
     {
-        $this->authorize('admin');
-
         return view('categorias.create')->with([
             'categoria' => new Categoria,
             'setores' => Estrutura::listarSetores(),
@@ -60,7 +62,6 @@ class CategoriaController extends Controller
      */
     public function store(CategoriaRequest $request)
     {
-        $this->authorize('admin');
         $validated = $request->validated();
         $categoria = Categoria::create($validated);
 
@@ -99,7 +100,6 @@ class CategoriaController extends Controller
      */
     public function show(Categoria $categoria)
     {
-        $this->authorize('admin');
         return view('categorias.show', compact('categoria'));
     }
 
@@ -111,8 +111,6 @@ class CategoriaController extends Controller
      */
     public function edit(Categoria $categoria)
     {
-        $this->authorize('admin');
-
         return view('categorias.edit')->with([
             'categoria' => $categoria,
             'setores' => Estrutura::listarSetores(),
@@ -131,7 +129,6 @@ class CategoriaController extends Controller
      */
     public function update(CategoriaRequest $request, Categoria $categoria)
     {
-        $this->authorize('admin');
         $validated = $request->validated();
         $categoria->update($validated);
 
@@ -172,8 +169,6 @@ class CategoriaController extends Controller
      */
     public function destroy(Categoria $categoria)
     {
-        $this->authorize('admin');
-
         if ($categoria->materials->isNotEmpty()){
             return redirect('/categorias')->with('alert-danger', 'Categoria ainda contém materiais. Por favor delete materiais antes!');
         }
@@ -189,7 +184,6 @@ class CategoriaController extends Controller
 
     public function barcodes(Request $request)
     {
-        $this->authorize('admin');
         $generator = new BarcodeGeneratorPNG();
         $materiais = Material::orderBy('codigo', 'asc');
         if($request->categoria_id[0] == null){

--- a/app/Http/Controllers/CursoHabilitacaoController.php
+++ b/app/Http/Controllers/CursoHabilitacaoController.php
@@ -10,7 +10,7 @@ use Uspdev\Replicado\Graduacao;
 class CursoHabilitacaoController extends Controller
 {
     public function __construct() {
-        $this->middleware('can:admin');
+        $this->middleware('can:manager');
     }
 
     public function index(){

--- a/app/Http/Controllers/MaterialController.php
+++ b/app/Http/Controllers/MaterialController.php
@@ -11,7 +11,7 @@ class MaterialController extends Controller
 {
     public function __construct()
     {
-        $this->middleware('can:admin', ['except' => ['index']]);
+        $this->middleware('can:manager', ['except' => ['index']]);
     }
     /**
      * Display a listing of the resource.

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 class SettingsController extends Controller
 {
     public function __construct() {
-        $this->middleware('can:admin');
+        $this->middleware('can:manager');
     }
 
     public function index(){

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -33,7 +33,7 @@ class AuthServiceProvider extends ServiceProvider
         $this->registerPolicies();
 
         Gate::define('balcao', function ($user) {
-            if(Gate::allows('admin') || Auth::user()->hasPermissionTo('balcao')) return true;
+            if(Gate::allows('manager') || Auth::user()->hasPermissionTo('balcao')) return true;
             $verifica = User::where('username', $user->username)->where('tipo', 'Balcao')->first();
             if($verifica){
                 return true;

--- a/config/laravel-usp-theme.php
+++ b/config/laravel-usp-theme.php
@@ -4,21 +4,21 @@ $submenu1 = [
     [
         'type' => 'header',
         'text' => '<i class="far fa-bookmark"></i> Categoria',
-        'can' => 'admin'
+        'can' => 'manager'
     ],
     [
         'text' => '<i class="fas fa-plus-circle"></i> Cadastrar Categoria',
         'url' => 'categorias/create',
-        'can' => 'admin'
+        'can' => 'manager'
     ],
     [
         'text' => '<i class="fas fa-list-ul"></i> Listar Categorias',
         'url' => 'categorias',
-        'can' => 'admin'
+        'can' => 'manager'
     ],
     [
         'type' => 'divider',
-        'can' => 'admin'
+        'can' => 'manager'
     ],
     [
         'type' => 'header',
@@ -28,7 +28,7 @@ $submenu1 = [
     [
         'text' => '<i class="fas fa-plus-circle"></i> Cadastrar Material',
         'url' => 'materials/create',
-        'can' => 'admin'
+        'can' => 'manager'
     ],
     [
         'text' => '<i class="fas fa-list-ul"></i> Listar Material',
@@ -104,7 +104,7 @@ $submenu2 = [
     [
         'text' => '<i class="fas fa-barcode"></i> Código de Barras',
         'url' => 'categorias/barcode',
-        'can' => 'admin'
+        'can' => 'manager'
     ],
 
 ];
@@ -142,7 +142,7 @@ $right_menu = [
         'title' => 'Configurações',
         'target' => '_blanck',
         'url' => config('app.url').'/settings',
-        'can' => 'admin'
+        'can' => 'manager'
     ],
     [
         'key' => 'senhaunica-socialite',

--- a/resources/views/materials/index.blade.php
+++ b/resources/views/materials/index.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
 @include('flash')
-    @can('admin')
+    @can('manager')
     <div class="row mb-3">
         <div class="col-sm">
             <a href="materials/create" class="btn btn-success">Novo Material</a>
@@ -19,7 +19,7 @@
                 <th>Descrição</th>
                 <th>Prazo de devolução</th>
                 <th>Ativo</th>
-                @can('admin')
+                @can('manager')
                 <th>Ações</th>
                 @endcan
             </tr>
@@ -27,12 +27,12 @@
         <tbody>
         @foreach($materials as $material)
             <tr>
-                <td><a @can('admin') href="materials/{{$material->id}}" @endcan>{{ $material->codigo }}</a></td>
+                <td><a @can('manager') href="materials/{{$material->id}}" @endcan>{{ $material->codigo }}</a></td>
                 <td>{{ $material->categoria->nome }}</td>
                 <td>{{ $material->descricao }}</td>
                 <td>{{$material->devolucao ? $material->prazo . ' dias ' . ($material->dias_da_semana ? 'semanais' : 'corridos') : 'Não possui'}}</td>
                 <td>{{ $material->ativo ? 'Sim' : 'Não' }}</td>
-                @can('admin')
+                @can('manager')
                 <td>
                     <a href="materials/{{$material->id}}/edit" class="btn btn-warning col-auto float-left"><i class="fas fa-pencil-alt"></i></a>
                     <form method="POST" style="width:42px;" class="float-left col-auto" action="materials/{{ $material->id }}">


### PR DESCRIPTION
Fix #69 

A permissão manager pode agora realizar as permissões de gerenciamento dos materiais, das categorias e da relação de cursos x habilitações.