### PR TITLE
Trocando ícones pelo método 'implode' para listar vinculos/setores da categoria

### DIFF
--- a/app/Http/Controllers/MaterialController.php
+++ b/app/Http/Controllers/MaterialController.php
@@ -106,6 +106,11 @@ class MaterialController extends Controller
      */
     public function destroy(Material $material)
     {
+        if($material->emprestimos()->exists()){
+            session()->flash('alert-danger', 'Este material não pode ser excluído pois já foi emprestado anteriormente.');
+            return back();
+        }
+
         $material->delete();
         return redirect('materials');
     }

--- a/resources/views/categorias/show.blade.php
+++ b/resources/views/categorias/show.blade.php
@@ -23,7 +23,7 @@
                     @if ($categoria->vinculos->isEmpty())
                         <td>Todos</td>
                     @else
-                        <td>@foreach($categoria->vinculos as $vinculo) {!!'<div class="d-inline-flex mr-2">&#x1F784; ' . $vinculo->nome . '</div>'!!} @endforeach</td>
+                        <td>{{$categoria->vinculos->pluck('nome')->implode(' / ')}}</td>
                     @endif
             </tr>
             <tr scope="row">
@@ -31,7 +31,7 @@
                     @if ($categoria->setores->isEmpty())
                         <td>Todos</td>
                     @else
-                        <td>@foreach($categoria->setores as $setor) {!!'<div class="d-inline-flex mr-2">&#x1F784; ' . $setor->nomset . '</div>'!!} @endforeach</td>
+                        <td>{{$categoria->setores->pluck('nomset')->implode(' / ')}}</td>
                     @endif
                 </tr>
     </table>


### PR DESCRIPTION
Além disso, ao tentar deletar um material que já foi emprestado previamente, agora é retornado um flash amigável avisando que esta ação não é possível.